### PR TITLE
pulled in changes where meta is editable and hideen from editor meta …

### DIFF
--- a/src/classes/class-se-event-post-type.php
+++ b/src/classes/class-se-event-post-type.php
@@ -211,6 +211,9 @@ class SE_Event_Post_Type {
 				'single'         => true,
 				'type'           => 'string',
 				'object_subtype' => self::$post_type,
+				'auth_callback'  => function () {
+					return current_user_can( 'edit_posts' );
+				},
 			)
 		);
 
@@ -222,6 +225,9 @@ class SE_Event_Post_Type {
 				'single'         => true,
 				'type'           => 'string',
 				'object_subtype' => self::$post_type,
+				'auth_callback'  => function () {
+					return current_user_can( 'edit_posts' );
+				},
 			)
 		);
 


### PR DESCRIPTION
…field

#### Changes proposed in this Pull Request

* 
This pull request introduces an `auth_callback` to the `register_meta` method in the `src/classes/class-se-event-post-type.php` file. The callback ensures that only users with the `edit_posts` capability can modify the meta fields.

Access control improvements:

* Added an `auth_callback` to the `register_meta` method to enforce permissions based on the `edit_posts` capability, ensuring only authorized users can edit post metadata. (`[[1]](diffhunk://#diff-1412c5700fff8340e2b4c8451a38920a841fbd8b98e970218910ed88a4fdcfd7R214-R216)`, `[[2]](diffhunk://#diff-1412c5700fff8340e2b4c8451a38920a841fbd8b98e970218910ed88a4fdcfd7R228-R230)`)

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

Mentions #
