### PR TITLE
You can exclude dates form the feed, so are hidden from the next and …

### DIFF
--- a/src/blocks/event-info/components/DateTimeGroup.js
+++ b/src/blocks/event-info/components/DateTimeGroup.js
@@ -1,4 +1,4 @@
-import React, { Fragment, useState } from 'react';
+import React, { Fragment, useState, useEffect } from 'react';
 import { __ } from '@wordpress/i18n';
 import {
 	BaseControl,
@@ -54,6 +54,11 @@ const DateTimeGroupNew = ({
 	const [currentEventDateTime, setCurrentEventDateTime] = useState(eventDateTime);
 	// Add state to track if this date has been removed
 	const [isRemoved, setIsRemoved] = useState(false);
+
+	// Update local state when eventDateTime prop changes (e.g., timezone update)
+	useEffect(() => {
+		setCurrentEventDateTime(eventDateTime);
+	}, [eventDateTime]);
 
 	// console.log({
 	// 	'eventDateTime': eventDateTime,

--- a/src/blocks/event-info/date-utils.js
+++ b/src/blocks/event-info/date-utils.js
@@ -4,6 +4,17 @@ import { __ } from '@wordpress/i18n';
 import { head, last } from 'lodash';
 
 /**
+ * Date and Time Utilities
+ *
+ * Utility functions for handling date/time operations, timezone conversions,
+ * and date formatting within the Simple Events plugin. Provides consistent
+ * date handling across the event management system.
+ *
+ * @package SimpleEvents
+ * @since   1.0.0
+ */
+
+/**
  * Date/Time Constants
  */
 export const DEFAULT_START_HOUR = 9;
@@ -30,12 +41,17 @@ TIMEZONES.unshift({
 });
 
 /**
- * Get the DST offset for a given timestamp and timezone
+ * Gets the DST offset for a given timestamp and timezone.
  *
- * @param {number} timestamp The timestamp to check
- * @param {string|null} timezone The timezone to check (defaults to current timezone)
- * @param {string} currentTimezone The current event timezone
- * @returns {number} The offset in minutes
+ * Calculates the daylight saving time offset for a specific timestamp
+ * within a given timezone. Handles timezone conversions and DST transitions.
+ *
+ * @since 1.0.0
+ *
+ * @param {number}      timestamp       The timestamp to check.
+ * @param {string|null} timezone        The timezone to check (defaults to current timezone).
+ * @param {string}      currentTimezone The current event timezone.
+ * @return {number} The offset in minutes.
  */
 export const getDstOffset = (timestamp, timezone = null, currentTimezone = TIMEZONE) => {
 	// Return no offset if the event timezone is the same as the site.
@@ -59,11 +75,16 @@ export const getDstOffset = (timestamp, timezone = null, currentTimezone = TIMEZ
 };
 
 /**
- * Creates a moment in the site timezone from the provided unix timestamp.
+ * Creates a moment object in the site timezone from a unix timestamp.
  *
- * @param {string} timestamp Timestamp to convert to a moment.
- * @param {boolean} formatted Whether to return a human-readable formatted string.
- * @param {string} currentTimezone The current timezone for the event
+ * Converts a unix timestamp to a moment object using the appropriate
+ * timezone offset. Can optionally return a formatted string instead.
+ *
+ * @since 1.0.0
+ *
+ * @param {string}  timestamp       Timestamp to convert to a moment.
+ * @param {boolean} formatted       Whether to return a human-readable formatted string.
+ * @param {string}  currentTimezone The current timezone for the event.
  * @return {moment.Moment|string} Human readable formatted string if `formatted` is true, moment object otherwise.
  */
 export const getMoment = (timestamp, formatted = false, currentTimezone = TIMEZONE) => {
@@ -79,10 +100,15 @@ export const getMoment = (timestamp, formatted = false, currentTimezone = TIMEZO
 };
 
 /**
- * Creates a timestamp from the provided date string.
+ * Creates a timestamp from a date string.
  *
- * @param {string} dateTime Date string to convert to a timestamp.
- * @param {string} currentTimezone The current timezone for the event
+ * Converts a date string to a unix timestamp, applying the appropriate
+ * timezone offset for accurate time representation.
+ *
+ * @since 1.0.0
+ *
+ * @param {string} dateTime         Date string to convert to a timestamp.
+ * @param {string} currentTimezone  The current timezone for the event.
  * @return {string} The timestamp, cast as a string.
  */
 export const getTimestamp = (dateTime, currentTimezone = TIMEZONE) => {
@@ -98,25 +124,39 @@ export const getTimestamp = (dateTime, currentTimezone = TIMEZONE) => {
 };
 
 /**
- * Get the start and end date from a collection of dates.
- * Will remove any event that has passed.
+ * Gets the start and end date from a collection of dates.
  *
- * @param {{all_day: boolean, datetime_start: string, datetime_end: string}[]} dates The dates to check.
- * @returns {{ datetime_start: string|null, datetime_end: string|null }}
+ * Analyzes a collection of event dates to determine the overall start and end
+ * times, filtering out dates that have already passed. Returns the earliest
+ * start date and latest end date from valid future dates.
+ *
+ * @since 1.0.0
+ *
+ * @param {Array} dates Array of date objects with all_day, start_date, and end_date properties.
+ * @return {Object} Object with start_date and end_date properties (strings or null).
  */
 export const getStartAndEndDate = (dates) => {
 	// iterate over and remove any that has passed.
 	const now = moment().utcOffset(OFFSET);
 	const filteredDates = dates.filter((date) => {
-		const endDate = moment.unix(date.datetime_end).utcOffset(OFFSET);
+		const endDate = moment.unix(date.end_date).utcOffset(OFFSET);
 		return endDate.isAfter(now);
 	});
 
-	// Closure that gets the first and last date.
+	/**
+	 * Gets the first and last date from the collection.
+	 *
+	 * Helper closure that extracts the earliest start date and
+	 * latest end date from the full date collection.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return {Object} Object with start_date and end_date properties.
+	 */
 	const getFirstAndLastDate = () => {
 		return {
-			datetime_start: moment.unix(head(dates).datetime_start).utcOffset(OFFSET).unix().toString(),
-			datetime_end: moment.unix(last(dates).datetime_end).utcOffset(OFFSET).unix().toString(),
+			start_date: moment.unix(head(dates).start_date).utcOffset(OFFSET).unix().toString(),
+			end_date: moment.unix(last(dates).end_date).utcOffset(OFFSET).unix().toString(),
 		};
 	};
 
@@ -131,8 +171,8 @@ export const getStartAndEndDate = (dates) => {
 
 	// Loop over the dates and set the start date as the earliest and the end as the latest.
 	filteredDates.forEach((date) => {
-		const startDateMoment = moment.unix(date.datetime_start).utcOffset(OFFSET);
-		const endDateMoment = moment.unix(date.datetime_end).utcOffset(OFFSET);
+		const startDateMoment = moment.unix(date.start_date).utcOffset(OFFSET);
+		const endDateMoment = moment.unix(date.end_date).utcOffset(OFFSET);
 
 		// If the end date has passed, skip it.
 		if (endDateMoment.isBefore(now)) {
@@ -140,9 +180,15 @@ export const getStartAndEndDate = (dates) => {
 		}
 
 		/**
-		 * Closure for setting the start or end date.
-		 * @param {moment.Moment} startDateMoment
-		 * @param {moment.Moment} endDateMoment
+		 * Sets the start or end date based on comparison logic.
+		 *
+		 * Helper closure for determining and setting the earliest start date
+		 * and latest end date from the filtered date collection.
+		 *
+		 * @since 1.0.0
+		 *
+		 * @param {moment.Moment} startDateMoment The start date moment to evaluate.
+		 * @param {moment.Moment} endDateMoment   The end date moment to evaluate.
 		 */
 		const setDate = (startDateMoment, endDateMoment) => {
 			// If the start date is before the current start date, set it.
@@ -166,23 +212,29 @@ export const getStartAndEndDate = (dates) => {
 
 	// If we have no startDate or endDate, just get the first from dates.
 	if (!startDate) {
-		startDate = moment.unix(head(filteredDates).datetime_start).utcOffset(OFFSET);
+		startDate = moment.unix(head(filteredDates).start_date).utcOffset(OFFSET);
 	}
 	if (!endDate) {
-		endDate = moment.unix(last(filteredDates).datetime_end).utcOffset(OFFSET);
+		endDate = moment.unix(last(filteredDates).end_date).utcOffset(OFFSET);
 	}
 	return {
-		datetime_start: startDate.unix().toString(),
-		datetime_end: endDate.unix().toString(),
+		start_date: startDate.unix().toString(),
+		end_date: endDate.unix().toString(),
 	};
 };
 
 /**
- * Creates a default date object for new events
+ * Creates a default date object for new events.
  *
- * @param {Array} existingDates Array of existing dates
- * @param {string} currentTimezone The current timezone
- * @returns {Object} New date object
+ * Generates a new event date object with sensible defaults based on
+ * existing dates and timezone. Sets the new date to be one day after
+ * the last existing date, or uses current time with default hours.
+ *
+ * @since 2.0.0
+ *
+ * @param {Array}  existingDates   Array of existing date objects.
+ * @param {string} currentTimezone The current timezone identifier.
+ * @return {Object} New date object with start_date, end_date, and flag properties.
  */
 export const createDefaultDate = (existingDates = [], currentTimezone = TIMEZONE) => {
 	// Set default date and time.
@@ -204,9 +256,6 @@ export const createDefaultDate = (existingDates = [], currentTimezone = TIMEZONE
 	eventStart.add(1, 'days');
 	eventEnd.add(1, 'days');
 
-	console.log('eventStart', eventStart);
-	console.log('eventEnd', eventEnd);
-
 	return {
 		start_date: wp.date.date('U', eventStart),
 		end_date: wp.date.date('U', eventEnd),
@@ -217,11 +266,17 @@ export const createDefaultDate = (existingDates = [], currentTimezone = TIMEZONE
 };
 
 /**
- * Combines a given date and time into a moment object.
+ * Combines a date and time into a moment object.
  *
- * @param {string} date The date to combine.
- * @param {string} time The time to combine.
- * @return {moment.Moment} The combined date and time.
+ * Takes separate date and time strings and combines them into a single
+ * moment object, preserving the date from the first parameter and the
+ * time from the second parameter.
+ *
+ * @since 1.0.0
+ *
+ * @param {string} date The date string to use.
+ * @param {string} time The time string to use.
+ * @return {moment.Moment} The combined date and time as a moment object.
  */
 export const combineDateAndTime = (date, time) => {
 	const timeMoment = moment(time);
@@ -235,9 +290,14 @@ export const combineDateAndTime = (date, time) => {
 };
 
 /**
- * Check if the current time format is 12-hour
+ * Checks if the current time format is 12-hour.
  *
- * @returns {boolean} True if 12-hour format
+ * Analyzes the WordPress date format settings to determine if the
+ * site is configured to use 12-hour time format (with AM/PM indicators).
+ *
+ * @since 2.0.0
+ *
+ * @return {boolean} True if 12-hour format is used, false otherwise.
  */
 export const is12HourTime = () => {
 	const timeFormat = DATE_SETTINGS.formats.datetime;

--- a/src/blocks/event-info/event-manager.js
+++ b/src/blocks/event-info/event-manager.js
@@ -3,29 +3,50 @@ import { getStartAndEndDate, createDefaultDate, getDstOffset, TIMEZONE, OFFSET }
 import moment from 'moment';
 
 /**
- * Creates a date manager service for handling event dates with change tracking
+ * Date Manager Service
  *
- * @param {Array} initialDates Initial array of date objects
- * @param {string} timezone Current timezone for the event
- * @param {Object} metaSync Optional meta sync object with meta and setMeta
- * @returns {Object} Date management service
+ * Creates a date manager service for handling event dates with change tracking,
+ * timezone management, and state synchronization. Provides a centralized way to
+ * manage event dates with automatic dirty state tracking and meta synchronization.
+ *
+ * @package SimpleEvents
+ * @since   2.0.0
  */
 
 /**
-	 * Creates a hash for a date object based on its start and end times
-	 *
-	 * @param string start The start time of the date
-	 * @param string end The end time of the date
-	 * @returns {string} A unique hash for the date
-	 */
-	const createDateHash = (start, end) => {
-		// Get the current timestamp.
-		const timestamp = Date.now();
-		// Create a hash using the start and end times along with the timestamp.
-		const hash = `${start}-${end}-${timestamp}`;
-		return hash;
-	}
+ * Creates a hash for a date object based on its start and end times.
+ *
+ * Generates a unique identifier for a date object using start time, end time,
+ * and current timestamp to ensure uniqueness across date operations.
+ *
+ * @since 2.0.0
+ *
+ * @param {string} start The start time of the date.
+ * @param {string} end   The end time of the date.
+ * @return {string} A unique hash for the date.
+ */
+const createDateHash = (start, end) => {
+	// Get the current timestamp.
+	const timestamp = Date.now();
+	// Create a hash using the start and end times along with the timestamp.
+	const hash = `${start}-${end}-${timestamp}`;
+	return hash;
+}
 
+/**
+ * Creates a date manager instance for handling event dates.
+ *
+ * Provides a comprehensive date management system with change tracking,
+ * timezone conversion, and state synchronization. Manages both original
+ * and current date states with automatic dirty flag tracking.
+ *
+ * @since 2.0.0
+ *
+ * @param {Array}  initialDates Array of initial date objects with dates property.
+ * @param {string} timezone     Current timezone for the event.
+ * @param {Object} metaSync     Optional meta sync object with meta and setMeta properties.
+ * @return {Object} Date management service with public interface.
+ */
 export const dateManager = (initialDates = [], timezone = '', metaSync = null) => {
 
 	// lOOP through dates and add a hash to each date
@@ -43,19 +64,16 @@ export const dateManager = (initialDates = [], timezone = '', metaSync = null) =
 	// Meta sync helpers
 	const { meta, setMeta } = metaSync || {};
 
-	console.log({
-		'originalDates': originalDates,
-		'currentDates': currentDates,
-		'originalTimezone': originalTimezone,
-		'currentTimezone': currentTimezone,
-		'isDirty': isDirty,
-	});
-
 	/**
-	 * Refresh the date manager with new dates
+	 * Refreshes the date manager with new dates.
 	 *
-	 * @param {Array} newDates - The new dates to set
-	 * @returns {Object} Updated date management service
+	 * Updates both original and current date states with new data,
+	 * adds hashes to dates if missing, and resets the dirty flag.
+	 *
+	 * @since 2.0.0
+	 *
+	 * @param {Array} newDates Array of new date objects to set.
+	 * @return {Object} Updated date management service state.
 	 */
 	const refreshWithNewDates = (newDates) => {
 		// Add hash to each date if not present
@@ -70,22 +88,18 @@ export const dateManager = (initialDates = [], timezone = '', metaSync = null) =
 		currentDates = clone(newDates);
 		isDirty = false;
 
-		console.log('DateManager refreshed with new dates:', {
-			originalDates,
-			currentDates,
-			originalTimezone,
-			currentTimezone,
-			isDirty
-		});
-
 		return getCurrentDates();
 	};
 
 	/**
-	 * Get the current dates and timezone info
+	 * Gets the current dates and timezone information.
 	 *
-	 * @return {Object}
+	 * Returns the current state including dates, timezone, and dirty flag.
+	 * Considers timezone changes when determining dirty state.
 	 *
+	 * @since 2.0.0
+	 *
+	 * @return {Object} Current dates object with dates, timezone, and isDirty properties.
 	 */
 	const getCurrentDates = () => {
 		const timezoneChanged = currentTimezone !== originalTimezone;
@@ -97,20 +111,31 @@ export const dateManager = (initialDates = [], timezone = '', metaSync = null) =
 	}
 
 	/**
-	 * Find a date by its hash
+	 * Finds a date by its hash identifier.
 	 *
-	 * @param {string} hash The hash of the date to find
-	 * @returns {Object} The date object
+	 * Searches through current dates to find a date object
+	 * matching the provided hash.
+	 *
+	 * @since 2.0.0
+	 *
+	 * @param {string} hash The hash identifier of the date to find.
+	 * @return {Object|undefined} The date object if found, undefined otherwise.
 	 */
 	const findDateByHash = (hash) => {
 		return currentDates.find(d => d.hash === hash);
 	}
 
 	/**
-	 * Update the timezone and convert all dates accordingly
+	 * Updates the timezone and converts all dates accordingly.
 	 *
-	 * @param {string} newTimezone The new timezone to set
-	 * @returns {Object} Updated date management service
+	 * Changes the event timezone and adjusts all date timestamps to
+	 * maintain the same local time in the new timezone. Updates meta
+	 * if sync is available.
+	 *
+	 * @since 2.0.0
+	 *
+	 * @param {string} newTimezone The new timezone identifier to set.
+	 * @return {Object} Updated date management service state.
 	 */
 	const updateTimezone = (newTimezone) => {
 		const updatedDates = clone(currentDates);
@@ -125,31 +150,31 @@ export const dateManager = (initialDates = [], timezone = '', metaSync = null) =
 
 		updatedDates.forEach((eventDateTime) => {
 			[
-				'datetime_start',
-				'datetime_end',
+				'start_date',
+				'end_date',
 			].forEach((key) => {
-				const dateTime = moment
-					.unix(eventDateTime[key])
-					.utcOffset(
-						getDstOffset(
-							eventDateTime[key],
-							currentTimezone,
-							currentTimezone
-						)
-					);
+				// Get the current DST offset
+				const currentOffset = getDstOffset(
+					eventDateTime[key],
+					currentTimezone,
+					currentTimezone
+				);
 
-				const newOffset =
-					'' !== targetTimezone
-						? getDstOffset(
-							eventDateTime[key],
-							targetTimezone,
-							targetTimezone
-						)
-						: OFFSET;
+				// Get the target DST offset
+				const targetOffset = '' !== targetTimezone
+					? getDstOffset(
+						eventDateTime[key],
+						targetTimezone,
+						targetTimezone
+					)
+					: OFFSET;
 
+				// Apply target timezone offset and keep same local time
 				eventDateTime[key] = String(
-					dateTime
-						.utcOffset(newOffset, true)
+					moment
+						.unix(eventDateTime[key])
+						.utcOffset(currentOffset)
+						.utcOffset(targetOffset, true)
 						.utc()
 						.unix()
 				);
@@ -169,32 +194,26 @@ export const dateManager = (initialDates = [], timezone = '', metaSync = null) =
 			});
 		}
 
-		console.log('Timezone updated:', {
-			newTimezone,
-			updatedDates,
-			currentTimezone,
-			isDirty
-		});
-
 		return getCurrentDates();
 	};
 
 	/**
-	 * Upsert a date to the dates.
+	 * Upserts a date to the event dates collection.
 	 *
-	 * Date
-	 * {
-	 * 	id: null|int,
-	 *  hash: string,
-	 *  start: string,
-	 * 	end: string,
-	 * 	allDay: boolean,
-	 * 	showOnFeed: boolean,
-	 * 	showOnCalendar: boolean
-	 * }
+	 * Updates an existing date if the hash matches, otherwise adds a new date.
+	 * Automatically generates hash if missing and maintains sorted order by start date.
 	 *
-	 * @param {Object} date Date object to add
-	 * @returns {Object} Updated date management service
+	 * @since 2.0.0
+	 *
+	 * @param {Object} date Date object to add or update with properties:
+	 *                      - id: null|int
+	 *                      - hash: string
+	 *                      - start_date: string
+	 *                      - end_date: string
+	 *                      - all_day: boolean
+	 *                      - hide_from_feed: boolean
+	 *                      - hide_from_calendar: boolean
+	 * @return {Object} Updated date management service state.
 	 */
 	const upsertDate = (date) => {
 		// If the date doesnt contain a hash, generate one
@@ -207,11 +226,9 @@ export const dateManager = (initialDates = [], timezone = '', metaSync = null) =
 		if (existingIndex !== -1) {
 			// If it exists, update the date
 			currentDates[existingIndex] = date;
-			console.log('updated date', date);
 		} else {
 			// If it doesn't exist, add the new date
 			currentDates.push(date);
-			console.log('new date', date);
 		}
 		// Mark as dirty
 		isDirty = true;
@@ -219,24 +236,24 @@ export const dateManager = (initialDates = [], timezone = '', metaSync = null) =
 		// Sort the dates by start date
 		currentDates = sortBy(currentDates, 'start_date');
 
-		console.log('currentDates', currentDates);
-		console.log('originalDates', originalDates);
-
 		return getCurrentDates();
 	}
 
 	/**
-	 * Remove a date from the dates.
+	 * Removes a date from the event dates collection.
 	 *
-	 * @param {Object} date Date object to remove
-	 * @returns {Object} Updated date management service
+	 * Finds and removes a date object by its hash identifier,
+	 * then maintains sorted order and marks state as dirty.
+	 *
+	 * @since 2.0.0
+	 *
+	 * @param {Object} date Date object to remove (must contain hash property).
+	 * @return {Object} Updated date management service state.
 	 */
 	const removeDate = (date) => {
-		console.log('removeDate', date);
 		// Find the index of the date
 		const index = currentDates.findIndex(d => d.hash === date.hash);
 		if (index !== -1) {
-			console.log('removing date', date, 'index', index);
 			// Remove the date
 			currentDates.splice(index, 1);
 			// Mark as dirty
@@ -248,21 +265,30 @@ export const dateManager = (initialDates = [], timezone = '', metaSync = null) =
 	}
 
 	/**
-	 * Add a new date to the dates.
+	 * Adds a new default date to the event dates collection.
 	 *
-	 * @returns {Object} Updated date management service
+	 * Creates a new date object with default values based on existing dates
+	 * and current timezone, then adds it to the collection.
+	 *
+	 * @since 2.0.0
+	 *
+	 * @return {Object} Updated date management service state.
 	 */
 	const addDate = () => {
 		const newDate = createDefaultDate(currentDates, currentTimezone);
 		upsertDate(newDate);
-		console.log('isDirty', isDirty);
 		return getCurrentDates();
 	}
 
 	/**
-	 * Revert the dates and timezone to the original state.
+	 * Reverts dates and timezone to their original state.
 	 *
-	 * @returns {Object} Updated date management service
+	 * Restores both dates and timezone to their initial values,
+	 * clears dirty flag, and syncs timezone back to meta if available.
+	 *
+	 * @since 2.0.0
+	 *
+	 * @return {Object} Reverted date management service state.
 	 */
 	const revertDates = () => {
 		currentDates = clone(originalDates);
@@ -276,12 +302,6 @@ export const dateManager = (initialDates = [], timezone = '', metaSync = null) =
 				se_event_timezone: originalTimezone
 			});
 		}
-
-		console.log('Reverted to original state:', {
-			originalDates,
-			originalTimezone,
-			isDirty
-		});
 
 		return getCurrentDates();
 	}

--- a/src/blocks/event-info/index.js
+++ b/src/blocks/event-info/index.js
@@ -1,8 +1,13 @@
 /* global lodash, ajaxurl */
 /**
- * BLOCK: Events Info
+ * Event Info Block
  *
- * Event date and location management.
+ * Gutenberg block for managing event date, time, location, and venue information.
+ * Provides an interface for adding multiple event dates with timezone support,
+ * venue and location details, external links, and calendar integration options.
+ *
+ * @package SimpleEvents
+ * @since   1.0.0
  */
 
 import './editor.scss';
@@ -54,9 +59,14 @@ import DateTimeGroupNew from './components/DateTimeGroup';
 const DATE_SETTINGS = getSettings(); // Still needed for timeFormat
 
 /**
- * Get the event dates from the custom rest API endpoint.
+ * Fetches event dates from the custom REST API endpoint.
  *
- * @returns {Promise<Array>} A promise that resolves to an array of event dates.
+ * Retrieves all event dates associated with the current post via the
+ * Simple Events REST API. Returns an empty array if no post ID is found.
+ *
+ * @since 2.0.0
+ *
+ * @return {Promise<Array>} Promise that resolves to an array of event date objects.
  */
 export const getEventDatePosts = () => {
 	// Get the current post id.
@@ -76,11 +86,17 @@ export const getEventDatePosts = () => {
 };
 
 /**
- * Save the event dates to the custom rest API endpoint.
+ * Saves event dates to the custom REST API endpoint.
  *
- * @param {Array} dates - The array of event dates to save.
- * @param {Object} dateManagerInstance - The date manager instance to refresh.
- * @returns {Promise<Array>} A promise that resolves to the saved event dates.
+ * Sends event dates to the server for persistence via the Simple Events
+ * REST API sync endpoint. Displays success/error notifications and optionally
+ * refreshes the date manager instance with updated data.
+ *
+ * @since 2.0.0
+ *
+ * @param {Array}       dates               Array of event date objects to save.
+ * @param {Object|null} dateManagerInstance Optional date manager instance to refresh after save.
+ * @return {Promise<Object>} Promise that resolves to the API response object.
  */
 export const saveEventDates = (dates, dateManagerInstance = null) => {
 	// Get the current post id.
@@ -99,8 +115,6 @@ export const saveEventDates = (dates, dateManagerInstance = null) => {
 			nonce: seSettings.syncDatesNonce
 		}
 	}).then((response) => {
-		console.log('Event dates saved successfully:', response);
-
 		// Show notification message if available
 		if (response.message) {
 			// Show success notification in bottom left
@@ -138,26 +152,21 @@ export const saveEventDates = (dates, dateManagerInstance = null) => {
 };
 
 /**
- * Auto-save event dates when they change.
+ * Auto-saves event dates when they change.
  *
- * @param {Array} dates - The array of event dates to auto-save.
- * @param {Object} dateManagerInstance - The date manager instance to refresh.
- * @returns {Promise<Array>} A promise that resolves to the saved event dates.
+ * Wrapper function for saveEventDates that handles automatic saving
+ * of event dates during user interactions.
+ *
+ * @since 2.0.0
+ *
+ * @param {Array}       dates               Array of event date objects to auto-save.
+ * @param {Object|null} dateManagerInstance Optional date manager instance to refresh.
+ * @return {Promise<Object>} Promise that resolves to the saved event dates response.
  */
 export const autoSaveEventDates = async (dates, dateManagerInstance = null) => {
 	try {
 		// Save to REST API
 		const savedDates = await saveEventDates(dates, dateManagerInstance);
-
-		// Also update the post meta to keep it in sync
-		const postId = window?.wp?.data?.select('core/editor')?.getCurrentPostId();
-		if (postId) {
-			window.wp.data.dispatch('core/editor').editPost({
-				meta: {
-					se_event_dates: savedDates.dates || savedDates,
-				},
-			});
-		}
 
 		return savedDates;
 	} catch (error) {
@@ -167,29 +176,28 @@ export const autoSaveEventDates = async (dates, dateManagerInstance = null) => {
 };
 
 /**
- * Save event dates when the post is being saved.
+ * Saves event dates when the post is being saved.
  *
- * @param {Array} dates - The array of event dates to save.
- * @param {Object} dateManagerInstance - The date manager instance to refresh.
- * @returns {Promise<Array>} A promise that resolves to the saved event dates.
+ * Handles saving event dates during WordPress post save operations.
+ * Also updates block attributes to ensure the saved dates with IDs
+ * are properly persisted in the block editor.
+ *
+ * @since 2.0.0
+ *
+ * @param {Array}       dates               Array of event date objects to save.
+ * @param {Object|null} dateManagerInstance Optional date manager instance to refresh.
+ * @return {Promise<Object>} Promise that resolves to the saved event dates response.
  */
 export const saveEventDatesOnPostSave = async (dates, dateManagerInstance = null) => {
 	try {
 		// Save to REST API
 		const savedDates = await saveEventDates(dates, dateManagerInstance);
-		console.log('Event dates saved on post save:', savedDates);
 
 		// Update the post meta to ensure the updated dates (with IDs) are persisted
 		const postId = window?.wp?.data?.select('core/editor')?.getCurrentPostId();
 		if (postId && savedDates) {
-			window.wp.data.dispatch('core/editor').editPost({
-				meta: {
-					se_event_dates: [],
-				},
-			});
-			console.log('Post meta updated with saved dates:', savedDates.dates || savedDates);
 
-			// Also update the block attributes to ensure the updated dates (with IDs) are persisted
+			// Update the block attributes to ensure the updated dates (with IDs) are persisted
 			const blocks = window.wp.data.select('core/block-editor').getBlocks();
 			const eventInfoBlock = blocks.find(block => block.name === 'simple-events/event-info');
 
@@ -200,7 +208,6 @@ export const saveEventDatesOnPostSave = async (dates, dateManagerInstance = null
 						eventDates: savedDates.dates || savedDates,
 					}
 				);
-				console.log('Block attributes updated with saved dates:', savedDates.dates || savedDates);
 			}
 		}
 
@@ -217,7 +224,15 @@ let dateManagerInstance = null;
 let gettingDates = false;
 
 /**
- * Initialize the date manager with resolved event date posts
+ * Initializes the date manager with resolved event date posts.
+ *
+ * Creates and configures a date manager instance with event dates fetched
+ * from the REST API. Handles post meta synchronization and timezone settings.
+ * Uses singleton pattern to avoid multiple initializations.
+ *
+ * @since 2.0.0
+ *
+ * @return {Promise<Object|null>} Promise that resolves to the date manager instance or null on error.
  */
 const initializeDateManager = async () => {
 	if (gettingDates || dateManagerInstance) {
@@ -227,8 +242,6 @@ const initializeDateManager = async () => {
 	gettingDates = true;
 	try {
 		const eventDatePosts = await getEventDatePosts();
-		console.log('eventDatePosts from getEventDatePosts:', eventDatePosts);
-		console.log('dateManager function:', dateManager);
 
 		// Get current post meta to pass to dateManager for sync
 		const currentPostId = window?.wp?.data?.select('core/editor')?.getCurrentPostId();
@@ -246,7 +259,6 @@ const initializeDateManager = async () => {
 		};
 
 		dateManagerInstance = dateManager(eventDatePosts, currentTimezone, metaSync);
-		console.log('dateManagerInstance after creation:', dateManagerInstance);
 		return dateManagerInstance;
 	} catch (error) {
 		console.error('Error initializing date manager:', error);
@@ -257,29 +269,31 @@ const initializeDateManager = async () => {
 };
 
 /**
- * Register: a Gutenberg Block.
+ * Registers the Event Info Gutenberg block.
  *
- * Registers a new block provided a unique name and an object defining its
- * behavior. Once registered, the block is made editor as an option to any
- * editor interface where blocks are implemented.
+ * Creates a custom block for event information management including dates,
+ * times, locations, venues, and related settings. The block provides both
+ * edit and preview modes with extensive customization options.
  *
- * @link https://wordpress.org/gutenberg/handbook/block-api/
- * @param {string} name     Block name.
- * @param {Object} settings Block settings.
- * @return {?WPBlock}          The block, if it has been successfully
- *                             registered; otherwise `undefined`.
+ * @since 1.0.0
+ *
+ * @see https://wordpress.org/gutenberg/handbook/block-api/
  */
 registerBlockType('simple-events/event-info', {
 	/**
-	 * The edit function describes the structure of your block in the context of the editor.
-	 * This represents what the editor will render when the block is used.
+	 * Block edit function.
 	 *
-	 * The "edit" property must be a valid function.
+	 * Defines the structure and behavior of the Event Info block in the editor.
+	 * Manages event dates through a date manager instance, handles post meta
+	 * synchronization, and provides interfaces for editing event information
+	 * including dates, times, locations, venues, and display options.
 	 *
-	 * @link https://wordpress.org/gutenberg/handbook/block-api/block-edit-save/
+	 * @since 1.0.0
 	 *
-	 * @param {Object} props Props.
-	 * @return {JSX.Element} JSX Component.
+	 * @param {Object} props               Block properties.
+	 * @param {Object} props.attributes    Block attributes including editMode and showOnFrontEnd.
+	 * @param {Function} props.setAttributes Function to update block attributes.
+	 * @return {JSX.Element} The block editor interface.
 	 */
 	edit: (props) => {
 		const { attributes, setAttributes } = props;
@@ -311,10 +325,8 @@ registerBlockType('simple-events/event-info', {
 		useEffect(() => {
 			const saveDatesOnPostSave = async () => {
 				if (isSavingPost && !isAutosavingPost && dateManagerState?.getCurrentDates()?.dates) {
-					console.log('Post is being saved, saving event dates...');
 					try {
 						await saveEventDatesOnPostSave(dateManagerState.getCurrentDates().dates, dateManagerState);
-						console.log('Event dates saved successfully on post save');
 					} catch (error) {
 						console.error('Failed to save event dates on post save:', error);
 					}
@@ -371,10 +383,26 @@ registerBlockType('simple-events/event-info', {
 			}
 		}, [dateManagerReady, isGettingDates]);
 
+		/**
+		 * Handles the Done button click event.
+		 *
+		 * Exits edit mode by setting the editMode attribute to false.
+		 *
+		 * @since 1.0.0
+		 */
 		const onDone = () => {
 			setAttributes({ editMode: false });
 		};
 
+		/**
+		 * Handles event location input changes.
+		 *
+		 * Updates the se_event_location meta field when the location input changes.
+		 *
+		 * @since 1.0.0
+		 *
+		 * @param {string} value The new location value.
+		 */
 		const onChangeEventLocation = (value) => {
 			setMeta({
 				...meta,
@@ -382,6 +410,16 @@ registerBlockType('simple-events/event-info', {
 			});
 		};
 
+		/**
+		 * Renders the block toolbar controls.
+		 *
+		 * Creates the edit and visibility toggle buttons that appear in the
+		 * block toolbar when the block is selected.
+		 *
+		 * @since 1.0.0
+		 *
+		 * @return {JSX.Element} The BlockControls component with toolbar buttons.
+		 */
 		const getBlockControls = () => (
 			<BlockControls>
 				<Toolbar
@@ -412,6 +450,14 @@ registerBlockType('simple-events/event-info', {
 		);
 
 		// Wrapper functions to trigger re-renders when dateManager state changes
+		/**
+		 * Handles adding a new date to the event.
+		 *
+		 * Calls the date manager's addDate method and triggers a re-render
+		 * by incrementing the refresh counter.
+		 *
+		 * @since 2.0.0
+		 */
 		const handleAddDate = () => {
 			if (dateManagerState?.addDate) {
 				dateManagerState.addDate();
@@ -419,6 +465,14 @@ registerBlockType('simple-events/event-info', {
 			}
 		};
 
+		/**
+		 * Handles reverting date changes.
+		 *
+		 * Calls the date manager's revertDates method and triggers a re-render
+		 * by incrementing the refresh counter.
+		 *
+		 * @since 2.0.0
+		 */
 		const handleRevertDates = () => {
 			if (dateManagerState?.revertDates) {
 				dateManagerState.revertDates();
@@ -462,7 +516,16 @@ registerBlockType('simple-events/event-info', {
 			}
 		} : null;
 
-		// Unsaved Changes Warning Component
+		/**
+		 * Renders the unsaved changes warning component.
+		 *
+		 * Displays a warning message when the date manager has unsaved changes,
+		 * informing the user that they need to save the post to persist changes.
+		 *
+		 * @since 2.0.0
+		 *
+		 * @return {JSX.Element|null} Warning component or null if no unsaved changes.
+		 */
 		const UnsavedChangesWarning = () => {
 			if (!dateManagerState?.getCurrentDates()?.isDirty) {
 				return null;
@@ -496,8 +559,21 @@ registerBlockType('simple-events/event-info', {
 			);
 		};
 
+		/**
+		 * Renders the event date/time component.
+		 *
+		 * Creates a list of DateTimeGroupNew components for each event date,
+		 * sorted by start date. Each component allows editing of individual
+		 * date and time information.
+		 *
+		 * @since 2.0.0
+		 *
+		 * @param {Object} props              Component properties.
+		 * @param {Array}  props.dates        Array of event date objects to render.
+		 * @param {number} props.refreshCounter Counter to force component re-renders.
+		 * @return {JSX.Element} Fragment containing the event dates interface.
+		 */
 		const EventDateTime = ({ dates, refreshCounter }) => {
-			console.log('dates ', dates);
 
 			const datesOutput = [];
 
@@ -508,6 +584,7 @@ registerBlockType('simple-events/event-info', {
 						eventDateTime={date}
 						removeDate={null}
 						hasMultipleDates={dates.length > 1}
+						currentTimezone={dateManagerState?.getCurrentDates()?.timezone ?? meta?.se_event_timezone ?? TIMEZONE}
 						dateManagerInstance={enhancedDateManagerInstance}
 					/>
 				);
@@ -524,6 +601,16 @@ registerBlockType('simple-events/event-info', {
 			);
 		};
 
+		/**
+		 * Renders the block preview mode.
+		 *
+		 * Displays the front-end representation of the block using ServerSideRender
+		 * with the current event data. Includes block controls and unsaved changes warning.
+		 *
+		 * @since 1.0.0
+		 *
+		 * @return {JSX.Element} The preview component with ServerSideRender.
+		 */
 		const renderPreview = () => (
 			<div {...useBlockProps()}>
 				{getBlockControls()}
@@ -548,8 +635,6 @@ registerBlockType('simple-events/event-info', {
 		if (!editMode) {
 			return renderPreview();
 		}
-
-		console.log('dateManagerState', dateManagerState);
 
 		return (
 			<div {...useBlockProps()}>
@@ -798,15 +883,15 @@ registerBlockType('simple-events/event-info', {
 	},
 
 	/**
-	 * The save function defines the way in which the different attributes should be combined
-	 * into the final markup, which is then serialized by Gutenberg into post_content.
+	 * Block save function.
 	 *
-	 * The "save" property must be specified and must be a valid function.
+	 * Defines how the block content is saved to the database. This block
+	 * uses dynamic rendering (ServerSideRender), so the save function
+	 * returns null and all content is generated server-side via PHP.
 	 *
-	 * @link https://wordpress.org/gutenberg/handbook/block-api/block-edit-save/
+	 * @since 1.0.0
 	 *
-	 * @param {Object} props Props.
-	 * @return {Mixed} JSX Frontend HTML.
+	 * @return {null} Returns null as this is a dynamic block.
 	 */
 	save: () => {
 		return null;

--- a/src/blocks/event-info/old-index.js
+++ b/src/blocks/event-info/old-index.js
@@ -1,0 +1,1055 @@
+/* global lodash, ajaxurl */
+/**
+ * BLOCK: Events Info
+ *
+ * Event date and location management.
+ */
+
+import './editor.scss';
+
+import moment from 'moment';
+import { clone, isEqual, sortBy, head, last, pull } from 'lodash';
+import { __ } from '@wordpress/i18n';
+import { registerBlockType } from '@wordpress/blocks';
+import { Fragment } from '@wordpress/element';
+import {
+	PanelRow,
+	Placeholder,
+	BaseControl,
+	Dropdown,
+	Button,
+	TextControl,
+	Toolbar,
+	Disabled,
+	CheckboxControl,
+	ComboboxControl,
+	DateTimePicker,
+	PanelBody,
+	ToggleControl,
+} from '@wordpress/components';
+import ServerSideRender from '@wordpress/server-side-render';
+import { getSettings } from '@wordpress/date';
+import {
+	BlockControls,
+	InspectorControls,
+	useBlockProps,
+} from '@wordpress/block-editor';
+import { withState } from '@wordpress/compose';
+import { useEntityProp } from '@wordpress/core-data';
+
+/**
+ * Constants
+ */
+const DEFAULT_START_HOUR = 9;
+const DEFAULT_END_HOUR = 10;
+const DATE_SETTINGS = getSettings(); // eslint-disable-line no-restricted-syntax
+
+const OFFSET = Number(DATE_SETTINGS.timezone.offset);
+const TIMEZONE = DATE_SETTINGS.timezone.string;
+let TIMEZONE_NAME = TIMEZONE;
+if ('' === TIMEZONE) {
+	TIMEZONE_NAME = 'UTC' + (OFFSET >= 0 ? '+' : '') + OFFSET;
+}
+const FORMAT = 'YYYY-MM-DD HH:mm';
+const TIMEZONES = moment.tz
+	.names()
+	.map((tz) => ({ label: tz, value: tz }));
+
+// Add an option to use the site settings.
+// (This label is as helpful as we can be since manual offsets have no string.)
+TIMEZONES.unshift({
+	label: __('Same as site', 'simple-events'),
+	value: '',
+});
+
+/**
+ * Get the start and end date from a collection of dates.
+ * Will remove any event that has passed.
+ *
+ * @param {{all_day: boolean, datetime_start: string, datetime_end: string}[]} dates The dates to check.
+ *
+ * returns {{ datetime_start: string, datetime_end: string }}
+ */
+const getStartAndEndDate = (dates) => {
+	// iterate over and remove any that has passed.
+	const now = moment().utcOffset(OFFSET);
+	const filteredDates = dates.filter((date) => {
+
+		const endDate = moment.unix(date.datetime_end).utcOffset(OFFSET);
+		return endDate.isAfter(now);
+	});
+
+	// If we have no filtered dates, but we had dates, before.
+	if (filteredDates.length === 0 && dates.length > 0) {
+		// Extract all start dates with the offset.
+		const allStartDates = dates.map((date) =>
+			moment.unix(date.datetime_start).utcOffset(OFFSET)
+		);
+		const allEndDates = dates.map((date) =>
+			moment.unix(date.datetime_end).utcOffset(OFFSET)
+		);
+
+		// Return the latest start date and earliest end date.
+		return {
+			datetime_start: moment.max(allStartDates).unix().toString(),
+			datetime_end: moment.max(allEndDates).unix().toString(),
+		}
+	}
+
+	let startDate = null;
+	let endDate = null;
+
+	// Loop over the dates and set the start date as the earliest and the end as the latest.
+	filteredDates.forEach((date) => {
+		const startDateMoment = moment.unix(date.datetime_start).utcOffset(OFFSET);
+		const endDateMoment = moment.unix(date.datetime_end).utcOffset(OFFSET);
+
+		// If the end date has passed, skip it.
+		if (endDateMoment.isBefore(now)) {
+			return;
+		}
+
+		/**
+		 * Closure for setting the start or end date.
+		 * @param {moment.Moment} startDateMoment
+		 * @param {moment.Moment} endDateMoment
+		 */
+		const setDate = (startDateMoment, endDateMoment) => {
+			// If the start date is before the current start date, set it.
+			if (!startDate || startDateMoment.isBefore(startDate) || (startDate.isAfter(startDateMoment) && startDate.isBefore(now))) {
+				startDate = startDateMoment;
+			}
+
+			// If the end date is after the current end date, set it.
+			if (!endDate || endDateMoment.isAfter(endDate)) {
+				endDate = endDateMoment;
+			}
+		};
+
+		// If the start date if after now
+		if (startDateMoment.isAfter(now) && endDateMoment.isAfter(now)) {
+			setDate(startDateMoment, endDateMoment);
+		} else if (startDateMoment.isBefore(now) && endDateMoment.isAfter(now)) {
+			setDate(startDateMoment, endDateMoment);
+		}
+	});
+
+	// If we have no startDate or endDate, just get the first from dates.
+	if (!startDate) {
+		startDate = moment.unix(head(filteredDates).datetime_start).utcOffset(OFFSET);
+	}
+	if (!endDate) {
+		endDate = moment.unix(last(filteredDates).datetime_end).utcOffset(OFFSET);
+	}
+
+	return {
+		datetime_start: startDate.unix().toString(),
+		datetime_end: endDate.unix().toString(),
+	};
+}
+
+
+/**
+ * Register: a Gutenberg Block.
+ *
+ * Registers a new block provided a unique name and an object defining its
+ * behavior. Once registered, the block is made editor as an option to any
+ * editor interface where blocks are implemented.
+ *
+ * @link https://wordpress.org/gutenberg/handbook/block-api/
+ * @param {string} name     Block name.
+ * @param {Object} settings Block settings.
+ * @return {?WPBlock}          The block, if it has been successfully
+ *                             registered; otherwise `undefined`.
+ */
+registerBlockType('simple-events/event-info', {
+	/**
+	 * The edit function describes the structure of your block in the context of the editor.
+	 * This represents what the editor will render when the block is used.
+	 *
+	 * The "edit" property must be a valid function.
+	 *
+	 * @link https://wordpress.org/gutenberg/handbook/block-api/block-edit-save/
+	 *
+	 * @param {Object} props Props.
+	 * @return {JSX.Element} JSX Component.
+	 */
+	edit: (props) => {
+		const { attributes, setAttributes } = props;
+		const { editMode, showOnFrontEnd } = attributes;
+
+		const [meta, setMeta] = useEntityProp(
+			'postType',
+			'se-event',
+			'meta'
+		);
+
+
+		// Sets the default timezone for calculations.
+
+		let currentTimezone = meta?.se_event_timezone;
+		if ('' === currentTimezone) {
+			currentTimezone = TIMEZONE;
+		}
+
+		const getDstOffset = (timestamp, timezone = null) => {
+			// Return no offset if the event timezone is the same as the site.
+			if (null === timezone) {
+				timezone = currentTimezone;
+			}
+
+			if ('' === timezone) {
+				return OFFSET;
+			}
+
+			// Get the timezone details.
+			const timezoneDetails = moment.tz.zone(timezone);
+
+			// Get the index of the current timezone offset i.e DST or non-DST. -1 at the end to account for search algorithm.
+			const untilIndex = timezoneDetails.untils.findIndex(function (
+				number
+			) {
+				return number / 1000 > timestamp;
+			});
+
+			return timezoneDetails.offsets[untilIndex] * -1;
+		};
+
+		/**
+		 * Creates a moment in the site timezone from the provided unix timestamp.
+		 *
+		 * @param {string}  timestamp Timestamp to convert to a moment.
+		 * @param {boolean} formatted Whether to return a human-readable formatted string.
+		 * @return {Mixed}             Human readable formatted string if `formatted` is true,
+		 *                             moment object otherwise.
+		 */
+		const getMoment = (timestamp, formatted = false) => {
+			const dateTime = moment
+				.unix(timestamp)
+				.utcOffset(getDstOffset(timestamp));
+
+			if (!formatted) {
+				return dateTime;
+			}
+
+			return dateTime.format(FORMAT);
+		};
+
+		/**
+		 * Creates a timestamp from the provided date string.
+		 *
+		 * @param {string} dateTime Date string to convert to a timestamp.
+		 * @return {string}          The timestamp, cast as a string.
+		 */
+		const getTimestamp = (dateTime) => {
+			return String(
+				moment(dateTime)
+					.utcOffset(
+						getDstOffset(moment(dateTime).unix()),
+						true
+					)
+					.utc()
+					.unix()
+			);
+		};
+
+		const onDone = () => {
+			setAttributes({ editMode: false });
+		};
+
+		const onChangeEventLocation = (value) => {
+			setMeta({
+				...meta,
+				se_event_location: value,
+			});
+		};
+
+		const maybeUpdateEventDateTime = (oldDate, newDate) => {
+			if (!isEqual(oldDate, newDate)) {
+				const updatedDates = sortBy(
+					meta?.se_event_dates.map((item) =>
+						item === oldDate ? newDate : item
+					),
+					'datetime_start'
+				);
+
+				setMeta({
+					...meta,
+					se_event_dates: updatedDates,
+					se_event_date_start: getStartAndEndDate(updatedDates).datetime_start,
+					se_event_date_end: getStartAndEndDate(updatedDates).datetime_end,
+				});
+			}
+		};
+
+		const getBlockControls = () => (
+			<BlockControls>
+				<Toolbar
+					controls={[
+						{
+							icon: 'edit',
+							title: __('Edit', 'simple-events'),
+							onClick: () =>
+								setAttributes({ editMode: !editMode }),
+							isActive: editMode,
+						},
+						{
+							icon: showOnFrontEnd ? 'visibility' : 'hidden',
+							title: __('Show on Front-End?', 'simple-events'),
+							onClick: () => {
+								setAttributes({
+									showOnFrontEnd: !showOnFrontEnd,
+								});
+								setMeta({
+									se_event_show_on_frontend: !showOnFrontEnd,
+								});
+							},
+							isActive: showOnFrontEnd,
+						},
+					]}
+				/>
+			</BlockControls>
+		);
+
+		const DateTimeGroup = withState({
+			tempEventDate: null,
+			tempEventTime: null,
+		})(
+			({
+				eventDateTime,
+				removeDate,
+				multiDay,
+				tempEventDate,
+				tempEventTime,
+				setState,
+			}) => {
+				const eventStart = getMoment(
+					eventDateTime.datetime_start,
+					true
+				);
+				const eventEnd = getMoment(eventDateTime.datetime_end, true);
+				const timeFormat = DATE_SETTINGS.formats.datetime;
+
+				// To know if the current timezone is a 12 hour time with look for an "a" in the time format.
+				// We also make sure this a is not escaped by a "/".
+				const is12HourTime = /a(?!\\)/i.test(
+					timeFormat
+						.toLowerCase() // Test only the lower case a
+						.replace(/\\\\/g, '') // Replace "//" with empty strings
+						.split('')
+						.reverse()
+						.join('') // Reverse the string and test for "a" not followed by a slash
+				);
+
+				/**
+				 * Combines a given date and time into a moment object.
+				 *
+				 * @param {string} date The date to combine.
+				 * @param {string} time The time to combine.
+				 *
+				 * @return {moment} The combined date and time.
+				 */
+				const combineDateAndTime = (date, time) => {
+					const timeMoment = moment(time);
+					const dateMoment = moment(date);
+
+					// Set the timeMoment's time to the dateMoment.
+					return dateMoment.set({
+						hour: timeMoment.get('hour'),
+						minute: timeMoment.get('minute'),
+					});
+				};
+
+				/**
+				 * Handle the set date and time button click.
+				 *
+				 * @param {boolean} isStartChange Whether this is start or end date change.
+				 *
+				 * @return {void}
+				 */
+				const setDateTimeHandler = (isStartChange) => {
+					// Ensure we have either new date or time in state.
+					if (!tempEventDate && !tempEventTime) {
+						return;
+					}
+
+					const newDate =
+						tempEventDate ||
+						(isStartChange ? eventStart : eventEnd);
+					const newTime =
+						tempEventTime ||
+						(isStartChange ? eventStart : eventEnd);
+
+					// Combine the new date and time and convert to a timestamp.
+					const newDateTime = getTimestamp(
+						combineDateAndTime(newDate, newTime)
+					);
+
+					const newEventDateTime = clone(eventDateTime);
+
+					if (isStartChange) {
+						newEventDateTime.datetime_start = newDateTime;
+
+						// Check if the new start time is after the cuurent end time.
+						if (
+							parseInt(newEventDateTime.datetime_start) >=
+							parseInt(newEventDateTime.datetime_end)
+						) {
+							// Set the new end time to be 1 hour after the start dateTime.
+							newEventDateTime.datetime_end = String(
+								parseInt(newEventDateTime.datetime_start) +
+								3600
+							);
+						}
+					} else {
+						newEventDateTime.datetime_end = newDateTime;
+
+						// Check if the new end time is before the current start time.
+						if (
+							parseInt(newEventDateTime.datetime_start) >=
+							parseInt(newEventDateTime.datetime_end)
+						) {
+							// Set the new start time to be 1 hour before the end dateTime.
+							newEventDateTime.datetime_start = String(
+								parseInt(newEventDateTime.datetime_end) - 3600
+							);
+						}
+					}
+
+					// Reset the temp date and time.
+					setState({
+						tempEventDate: null,
+						tempEventTime: null,
+					});
+
+
+					maybeUpdateEventDateTime(eventDateTime, newEventDateTime);
+				};
+
+				/**
+				 * Handles DateTimePicker changes.
+				 *
+				 * @param {string} currentDateTime The current dateTime.
+				 * @param {string} newDateTime     The new selected dateTime.
+				 *
+				 * @return {void}
+				 */
+				const datePickerHandler = (currentDateTime, newDateTime) => {
+					// Compare the date without time to see if the time or date was changed.
+					const isDateChange =
+						moment(currentDateTime).format('YYYY-MM-DD') ===
+						moment(newDateTime).format('YYYY-MM-DD');
+					const stateUpdate = isDateChange
+						? { tempEventTime: newDateTime }
+						: { tempEventDate: newDateTime };
+					setState(stateUpdate);
+				};
+
+				return (
+					<div className="se-datetimegroup-container">
+						<div className="se-datetimegroup-controls">
+							<BaseControl
+								label={__(
+									'Start Date/Time',
+									'simple-events'
+								)}
+							>
+								<Dropdown
+									contentClassName="se-datetime-popover se-datetime-popover__time"
+									popoverProps={{ placement: 'bottom' }}
+									renderToggle={({ isOpen, onToggle }) => (
+										<Button
+											className="se-datetime-popover__button"
+											variant="secondary"
+											onClick={() => {
+												onToggle();
+											}}
+											aria-expanded={isOpen}
+										>
+											{eventDateTime.all_day
+												? wp.date.format(
+													'F j, Y',
+													eventStart
+												)
+												: wp.date.format(
+													timeFormat,
+													eventStart
+												)}
+										</Button>
+									)}
+									renderContent={() => (
+										<Fragment>
+											<DateTimePicker
+												currentDate={eventStart}
+												is12Hour={is12HourTime}
+												onChange={(newDateTime) =>
+													datePickerHandler(
+														eventStart,
+														newDateTime
+													)
+												}
+												__nextRemoveHelpButton
+												__nextRemoveResetButton
+											/>
+											<Button
+												className="se-datetime-popover__set-datetime"
+												onClick={() =>
+													setDateTimeHandler(true)
+												}
+												variant="secondary"
+											>
+												{__(
+													'Set time',
+													'simple-events'
+												)}
+											</Button>
+										</Fragment>
+									)}
+								/>
+							</BaseControl>
+							<BaseControl
+								label={__('End Date/Time', 'simple-events')}
+							>
+								<Dropdown
+									contentClassName="se-datetime-popover se-datetime-popover__time"
+									popoverProps={{ placement: 'bottom' }}
+									renderToggle={({ isOpen, onToggle }) => (
+										<Button
+											className="se-datetime-popover__button"
+											variant="secondary"
+											onClick={() => {
+												onToggle();
+											}}
+											aria-expanded={isOpen}
+											disabled={eventDateTime.all_day}
+										>
+											{eventDateTime.all_day
+												? '--:--'
+												: wp.date.format(
+													timeFormat,
+													eventEnd
+												)}
+										</Button>
+									)}
+									renderContent={() => (
+										<Fragment>
+											<DateTimePicker
+												currentDate={eventEnd}
+												is12Hour={is12HourTime}
+												onChange={(newDateTime) =>
+													datePickerHandler(
+														eventEnd,
+														newDateTime
+													)
+												}
+												__nextRemoveHelpButton
+												__nextRemoveResetButton
+											/>
+											<Button
+												className="se-datetime-popover__set-datetime"
+												onClick={() =>
+													setDateTimeHandler(false)
+												}
+												variant="secondary"
+												text={__(
+													'Set time',
+													'simple-events'
+												)}
+											/>
+										</Fragment>
+									)}
+								/>
+							</BaseControl>
+							<BaseControl>
+								<CheckboxControl
+									label={__('All day', 'simple-events')}
+									className='se-all-day-checkbox'
+									checked={eventDateTime.all_day}
+									onChange={() => {
+										const newEventDateTime =
+											clone(eventDateTime);
+
+										newEventDateTime.all_day =
+											!eventDateTime.all_day;
+
+										newEventDateTime.datetime_start =
+											getMoment(
+												newEventDateTime.datetime_start
+											);
+										newEventDateTime.datetime_end =
+											getMoment(
+												newEventDateTime.datetime_end
+											);
+
+										// If all day event, set time between 00:00 and 23:59.
+										if (newEventDateTime.all_day) {
+											newEventDateTime.datetime_start.startOf(
+												'date'
+											);
+											newEventDateTime.datetime_end.endOf(
+												'date'
+											);
+										} else {
+											newEventDateTime.datetime_start
+												.hour(DEFAULT_START_HOUR)
+												.minute(0);
+											newEventDateTime.datetime_end
+												.hour(DEFAULT_END_HOUR)
+												.minute(0);
+										}
+
+										newEventDateTime.datetime_start =
+											getTimestamp(
+												newEventDateTime.datetime_start
+											);
+										newEventDateTime.datetime_end =
+											getTimestamp(
+												newEventDateTime.datetime_end
+											);
+
+										const updatedDates = sortBy(
+											meta?.se_event_dates.map((item) =>
+												item === eventDateTime
+													? newEventDateTime
+													: item
+											),
+											'datetime_start'
+										);
+
+										setMeta({
+											...meta,
+											se_event_dates: updatedDates,
+											se_event_date_start: getStartAndEndDate(updatedDates).datetime_start,
+											se_event_date_end: getStartAndEndDate(updatedDates).datetime_end,
+										});
+									}}
+								/>
+							</BaseControl>
+							{multiDay && (
+								<div className="se-datetime-control__delete">
+									<Button
+										isDestructive
+										icon="no-alt"
+										label={__(
+											'Remove date',
+											'simple-events'
+										)}
+										onClick={() =>
+											removeDate(eventDateTime)
+										}
+									/>
+								</div>
+							)}
+						</div>
+					</div>
+				);
+			}
+		);
+
+		const EventDateTime = ({ dates }) => {
+			const addNewDate = () => {
+				const existingDates =
+					!dates || 0 === dates.length ? [] : dates;
+
+				// Set default date and time.
+				let eventStart = moment().utcOffset(OFFSET);
+
+				eventStart.hour(DEFAULT_START_HOUR);
+				eventStart.minute(0);
+				eventStart.second(0);
+
+				let eventEnd = eventStart.clone();
+
+				eventEnd.hour(DEFAULT_END_HOUR);
+
+				// Override with existing date if there is one.
+				if (existingDates.length) {
+					eventStart = getMoment(
+						last(existingDates).datetime_start
+					);
+					eventEnd = getMoment(last(existingDates).datetime_end);
+				}
+
+				// Set default date to be +1 day from the last date.
+				eventStart.add(1, 'days');
+				eventEnd.add(1, 'days');
+
+				const updatedDates = sortBy(
+					[
+						...existingDates,
+						{
+							datetime_start: wp.date.date('U', eventStart),
+							datetime_end: wp.date.date('U', eventEnd),
+							all_day: false,
+						},
+					],
+					'datetime_start'
+				);
+
+				setMeta({
+					...meta,
+					se_event_dates: updatedDates,
+					se_event_date_start: getStartAndEndDate(updatedDates).datetime_start,
+					se_event_date_end: getStartAndEndDate(updatedDates).datetime_end,
+				});
+			};
+
+			const removeDate = (date) => {
+				if (!dates.length) {
+					return;
+				}
+
+				const updatedDates = pull(dates, date);
+
+				setMeta({
+					...meta,
+					se_event_dates: updatedDates,
+					se_event_date_start: getStartAndEndDate(updatedDates).datetime_start,
+					se_event_date_end: getStartAndEndDate(updatedDates).datetime_end,
+				});
+			};
+
+			// If no dates, add a date.
+			if (!dates || 0 === dates.length) {
+				addNewDate();
+			}
+
+			const datesOutput = [];
+
+			sortBy(dates, 'datetime_start').forEach((date, index) => {
+				datesOutput.push(
+					<DateTimeGroup
+						key={index}
+						eventDateTime={date}
+						removeDate={removeDate}
+						multiDay={dates.length > 1}
+					/>
+				);
+			});
+
+			return (
+				<Fragment>
+					<span className="se-datetimegroup-controls-label">
+						{__('Date & Time', 'simple-events')}
+					</span>
+					{datesOutput}
+					<div className="se-datetime-addmore">
+						<Button isLink onClick={() => addNewDate()}>
+							{__('+ Add another date', 'simple-events')}
+						</Button>
+					</div>
+				</Fragment>
+			);
+		};
+
+		const renderPreview = () => (
+			<div {...useBlockProps()}>
+				{getBlockControls()}
+				<Disabled>
+					<ServerSideRender
+						block="simple-events/event-info"
+						attributes={{
+							eventVenue: meta?.se_event_venue,
+							eventLocation: meta?.se_event_location,
+							eventDates: meta?.se_event_dates,
+							eventTimezone: meta?.se_event_timezone,
+							externalLink: meta?.se_event_external_link,
+							externalLinkLabel: meta?.se_event_external_link_label,
+							addCalendarLinks: meta?.se_event_add_calendar_links,
+						}}
+					/>
+				</Disabled>
+			</div>
+		);
+
+		// Show editMode if no location or date set.
+		if (
+			meta?.se_event_location.length === 0 &&
+			(!meta?.se_event_dates || !meta?.se_event_dates?.length)
+		) {
+			setAttributes({ editMode: true });
+		}
+
+		if (!editMode) {
+			return renderPreview();
+		}
+
+		return (
+			<div {...useBlockProps()}>
+				{getBlockControls()}
+				<Placeholder
+					label={__('Event Information', 'simple-events')}
+					icon="calendar"
+					isColumnLayout
+					className={props.className}
+				>
+					<EventDateTime dates={meta?.se_event_dates} />
+					<TextControl
+						className="se-location-label"
+						label={__('Venue', 'simple-events')}
+						value={meta?.se_event_venue}
+						onChange={(value) => setMeta({ ...meta, se_event_venue: value })}
+						type="text"
+					/>
+					<TextControl
+						className="se-location-label"
+						label={__('Location', 'simple-events')}
+						value={meta?.se_event_location}
+						onChange={onChangeEventLocation}
+						type="text"
+					/>
+					<TextControl
+						className="se-location-label"
+						label={__('External Link', 'simple-events')}
+						value={meta?.se_event_external_link}
+						onChange={(url) =>
+							setMeta({ ...meta, se_event_external_link: url })
+						}
+						type="url"
+					/>
+					{meta?.se_event_external_link && (
+						<>
+							<TextControl
+								className="se-location-label"
+								label={__('External Link Label', 'simple-events')}
+								value={meta?.se_event_external_link_label}
+								onChange={(value) =>
+									setMeta({
+										...meta,
+										se_event_external_link_label: value,
+									})
+								}
+								type="text"
+							/>
+							<CheckboxControl
+								label={__(
+									'Open external link from calendar',
+									'simple-events'
+								)}
+								checked={meta?.se_open_external_link ?? false}
+								onChange={(value) => {
+									setMeta({
+										...meta,
+										se_open_external_link: value,
+									});
+								}}
+							/>
+						</>
+
+					)}
+
+					<Button
+						className="se__button-done"
+						variant="primary"
+						onClick={onDone}
+						text={__('Done', 'simple-events')}
+					/>
+				</Placeholder>
+				<InspectorControls>
+					<PanelBody title={__('Settings', 'simple-events')}>
+						<PanelRow className="se-site-timezone-label">
+							{__('Site TimeZone', 'simple-events')}:{' '}
+							<strong>{TIMEZONE_NAME}</strong>{' '}
+							<a
+								target="_blank"
+								href={ajaxurl.replace(
+									'admin-ajax.php',
+									'options-general.php#timezone_string'
+								)}
+								rel="noreferrer"
+							>
+								({__('Change', 'simple-events')})
+							</a>
+						</PanelRow>
+						<ComboboxControl
+							className="se-timezone-label"
+							label={__('Time Zone', 'simple-events')}
+							help={__(
+								"Events default to the site's time zone as configured in the WordPress settings. If this event is happening in a different region, manually set the time zone here.",
+								'simple-events'
+							)}
+							value={meta?.se_event_timezone ?? TIMEZONE}
+							options={TIMEZONES}
+							onChange={(value) => {
+								const updatedDates = clone(
+									meta?.se_event_dates ?? []
+								);
+
+								// Ensure that the value is a string.
+								value = !Boolean(value) ? '' : value;
+								currentTimezone = value;
+
+								if ('' === value) {
+									currentTimezone = TIMEZONE;
+								}
+
+								updatedDates.forEach((eventDateTime) => {
+									[
+										'datetime_start',
+										'datetime_end',
+									].forEach((key) => {
+										const dateTime = moment
+											.unix(eventDateTime[key])
+											.utcOffset(
+												getDstOffset(
+													eventDateTime[key],
+													meta?.se_event_timezone
+												)
+											);
+
+										const newOffset =
+											'' !== currentTimezone
+												? getDstOffset(
+													eventDateTime[key],
+													currentTimezone
+												)
+												: OFFSET;
+
+										eventDateTime[key] = String(
+											dateTime
+												.utcOffset(newOffset, true)
+												.utc()
+												.unix()
+										);
+									});
+								});
+
+								setMeta({
+									...meta,
+									se_event_dates: updatedDates,
+									se_event_date_start: getStartAndEndDate(updatedDates).datetime_start,
+									se_event_date_end: getStartAndEndDate(updatedDates).datetime_end,
+									se_event_timezone: value,
+								});
+							}}
+						/>
+						<ToggleControl
+							label={__(
+								'Display Time Zone in Front-end',
+								'simple-events'
+							)}
+							checked={meta?.se_event_display_timezone ?? false}
+							onChange={(value) =>
+								setMeta({
+									...meta,
+									se_event_display_timezone: value,
+								})
+							}
+						/>
+						<ToggleControl
+							label={__(
+								'Group event dates with matching times',
+								'simple-events'
+							)}
+							checked={meta?.se_event_display_grouped ?? false}
+							onChange={(value) =>
+								setMeta({
+									...meta,
+									se_event_display_grouped: value,
+								})
+							}
+						/>
+						<ToggleControl
+							label={__('Hide Start Time', 'simple-events')}
+							help={__(
+								'Hides the Start Time on the Front-end'
+							)}
+							checked={meta?.se_event_hide_start_time ?? false}
+							onChange={(value) =>
+								setMeta({
+									...meta,
+									se_event_hide_start_time: value,
+								})
+							}
+						/>
+						<ToggleControl
+							label={__('Hide End Timer', 'simple-events')}
+							help={__('Hides the End Time on the Front-end')}
+							checked={meta?.se_event_hide_end_time ?? false}
+							onChange={(value) =>
+								setMeta({
+									...meta,
+									se_event_hide_end_time: value,
+								})
+							}
+						/>
+						<ToggleControl
+							label={__('Show "Add to calendar" links', 'simple-events')}
+							help={__('Shows the "Add to calendar" links on the Front-end', 'simple-events')}
+							checked={meta?.se_event_add_calendar_links ?? false}
+							onChange={(value) =>
+								setMeta({
+									...meta,
+									se_event_add_calendar_links: value,
+								})
+							}
+						/>
+						<ToggleControl
+							label={__(
+								'Open event in new window',
+								'simple-events'
+							)}
+							help={__(
+								'Open the event in new window from calender',
+								'simple-events'
+							)}
+							checked={
+								meta?.se_event_open_in_new_window ?? false
+							}
+							onChange={(value) =>
+								setMeta({
+									...meta,
+									se_event_open_in_new_window: value,
+								})
+							}
+						/>
+					</PanelBody>
+					<PanelBody title={__('Calendar Modal Configuration', 'simple-events')}>
+						<ToggleControl
+							label={__('Enable Event Modal', 'simple-events')}
+							help={__(
+								'Enable modal for this event.',
+								'simple-events'
+							)}
+							checked={meta?.se_event_modal_access ?? true}
+							onChange={(value) => setMeta({ ...meta, se_event_modal_access: value })}
+						/>
+						<ToggleControl
+							label={__('Show Event Title in Modal', 'simple-events')}
+							help={__(
+								'Toggle to show/hide the title of the event in the modal.',
+								'simple-events'
+							)}
+							checked={meta?.se_show_modal_title ?? true}
+							onChange={(value) => setMeta({ ...meta, se_show_modal_title: value })}
+						/>
+						<ToggleControl
+							label={__('Show Event Excerpt in Modal', 'simple-events')}
+							help={__(
+								'Toggle to show/hide the excerpt of the event in the modal.',
+								'simple-events'
+							)}
+							checked={meta?.se_show_modal_excerpt ?? true}
+							onChange={(value) => setMeta({ ...meta, se_show_modal_excerpt: value })}
+						/>
+					</PanelBody>
+				</InspectorControls>
+			</div>
+		);
+	},
+
+	/**
+	 * The save function defines the way in which the different attributes should be combined
+	 * into the final markup, which is then serialized by Gutenberg into post_content.
+	 *
+	 * The "save" property must be specified and must be a valid function.
+	 *
+	 * @link https://wordpress.org/gutenberg/handbook/block-api/block-edit-save/
+	 *
+	 * @param {Object} props Props.
+	 * @return {Mixed} JSX Frontend HTML.
+	 */
+	save: () => {
+		return null;
+	},
+});

--- a/src/classes/class-date-display-formatter.php
+++ b/src/classes/class-date-display-formatter.php
@@ -504,7 +504,8 @@ class SE_Date_Display_Formatter {
 		// iterate over the dates and group them by the start and end times.
 		foreach ( $event_dates as $date ) {
 			// If this event is all day.
-			if ( $date['all_day'] ) {
+			if ( true === (bool) $date['all_day'] ) {
+				// adump($date['all_day']);
 				$groups['all_day'][] = $date;
 				continue;
 			}
@@ -515,6 +516,7 @@ class SE_Date_Display_Formatter {
 			// Add the date to the group.
 			$groups[ $start . ' - ' . $end ][] = $date;
 		}
+		// adump($groups);
 
 		// Iterate over each group, and break them down to the starting month.
 		foreach ( $groups as $group ) {
@@ -548,7 +550,7 @@ class SE_Date_Display_Formatter {
 			}
 
 			foreach ( $dates as $month_dates ) {
-					$dates_string = $this->join_string( array_column( $month_dates, 'display_date' ), ', ', ' and ' );
+				$dates_string = $this->join_string( array_column( $month_dates, 'display_date' ), ', ', ' and ' );
 
 				// Lets start compiling the output.
 				$output = '';

--- a/src/classes/class-se-blocks.php
+++ b/src/classes/class-se-blocks.php
@@ -247,7 +247,7 @@ class SE_Blocks {
 
 		// Event time / date.
 		$event_dates = se_event_get_event_dates( $post_ID );
-// dump($event_dates, $attributes['eventDates'] );
+// adump([$event_dates, $attributes['eventDates']] );
 		// Previewing?
 		if ( ! empty( $attributes['eventDates'] ) ) {
 			$event_dates = $attributes['eventDates'];

--- a/src/classes/class-se-event-post-type.php
+++ b/src/classes/class-se-event-post-type.php
@@ -257,24 +257,13 @@ class SE_Event_Post_Type {
 			array(
 				'single'       => true,
 				'type'         => 'array',
-				'show_in_rest' => array(
-					'schema' => array(
-						'items' => array(
-							'type'       => 'object',
-							'properties' => array(
-								'datetime_start' => array(
-									'type' => 'string',
-								),
-								'datetime_end'   => array(
-									'type' => 'string',
-								),
-								'all_day'        => array(
-									'type' => 'boolean',
-								),
-							),
-						),
-					),
-				),
+				'default'      => array(),
+				'sanitize_callback' => function ( $value ) {
+					if ( is_null( $value ) || ! is_array( $value ) ) {
+						return array();
+					}
+					return $value;
+				},
 			)
 		);
 

--- a/src/template-functions.php
+++ b/src/template-functions.php
@@ -411,6 +411,11 @@ function se_event_get_next_event( int $event_id, ?int $event_date_id = null ): ?
 				'compare' => '>',
 				'type'    => 'NUMERIC',
 			),
+			array(
+				'key'     => 'se_event_hide_from_feed',
+				'value'   => 1,
+				'compare' => '!=',
+			),
 		),
 	);
 	// If we dont allow grouping, add the event id to parent not in.
@@ -467,6 +472,11 @@ function se_event_get_previous_event( int $event_id, ?int $event_date_id = null 
 				'value'   => get_post_meta( $event_date_id, 'se_event_date_start', true ),
 				'compare' => '<',
 				'type'    => 'NUMERIC',
+			),
+			array(
+				'key'     => 'se_event_hide_from_feed',
+				'value'   => 1,
+				'compare' => '!=',
 			),
 		),
 	);


### PR DESCRIPTION
…previous. Also patched the issue where you cant change the timezone correctly

#### Changes proposed in this Pull Request
This pull request introduces enhancements to the date and time management system within the Simple Events plugin. Key updates include improved state synchronization, timezone handling, and comprehensive documentation for utility functions and services. The changes aim to streamline event management, ensure accurate date/time operations, and improve code readability and maintainability.

### Updates to `DateTimeGroup` Component:
* Added `useEffect` to synchronize `currentEventDateTime` state with `eventDateTime` prop changes, ensuring consistency when timezone updates occur. [[1]](diffhunk://#diff-474b638e848dcef5f35c6872965af7ca6c47229accca97e44901dcd1e44ed04cL1-R1) [[2]](diffhunk://#diff-474b638e848dcef5f35c6872965af7ca6c47229accca97e44901dcd1e44ed04cR58-R62)

### Enhancements to `date-utils.js`:
* Added detailed JSDoc comments for utility functions (`getDstOffset`, `getMoment`, `getTimestamp`, `getStartAndEndDate`, `createDefaultDate`, `combineDateAndTime`, `is12HourTime`) to improve clarity and usage documentation. [[1]](diffhunk://#diff-5addde9c7b2e787e869fc169bd2275845bb76b6d71777b63356d6573065f0269R6-R16) [[2]](diffhunk://#diff-5addde9c7b2e787e869fc169bd2275845bb76b6d71777b63356d6573065f0269L33-R54) [[3]](diffhunk://#diff-5addde9c7b2e787e869fc169bd2275845bb76b6d71777b63356d6573065f0269L62-R87) [[4]](diffhunk://#diff-5addde9c7b2e787e869fc169bd2275845bb76b6d71777b63356d6573065f0269L82-R111) [[5]](diffhunk://#diff-5addde9c7b2e787e869fc169bd2275845bb76b6d71777b63356d6573065f0269L101-R159) [[6]](diffhunk://#diff-5addde9c7b2e787e869fc169bd2275845bb76b6d71777b63356d6573065f0269L134-R191) [[7]](diffhunk://#diff-5addde9c7b2e787e869fc169bd2275845bb76b6d71777b63356d6573065f0269L169-R237) [[8]](diffhunk://#diff-5addde9c7b2e787e869fc169bd2275845bb76b6d71777b63356d6573065f0269L207-L209) [[9]](diffhunk://#diff-5addde9c7b2e787e869fc169bd2275845bb76b6d71777b63356d6573065f0269L220-R279) [[10]](diffhunk://#diff-5addde9c7b2e787e869fc169bd2275845bb76b6d71777b63356d6573065f0269L238-R300)

### Improvements to `event-manager.js`:
* Introduced `dateManager` service with enhancements for managing event dates, including change tracking, timezone conversions, and state synchronization. Added JSDoc comments for methods like `refreshWithNewDates`, `getCurrentDates`, `findDateByHash`, `updateTimezone`, `upsertDate`, and `removeDate`. [[1]](diffhunk://#diff-b522fb3b70dd0c53a2c7c56b3ea8218fe73033c4985b601f96e9650d58fe6e83L6-R26) [[2]](diffhunk://#diff-b522fb3b70dd0c53a2c7c56b3ea8218fe73033c4985b601f96e9650d58fe6e83R36-R49) [[3]](diffhunk://#diff-b522fb3b70dd0c53a2c7c56b3ea8218fe73033c4985b601f96e9650d58fe6e83L46-R76) [[4]](diffhunk://#diff-b522fb3b70dd0c53a2c7c56b3ea8218fe73033c4985b601f96e9650d58fe6e83L73-R102) [[5]](diffhunk://#diff-b522fb3b70dd0c53a2c7c56b3ea8218fe73033c4985b601f96e9650d58fe6e83L100-R138) [[6]](diffhunk://#diff-b522fb3b70dd0c53a2c7c56b3ea8218fe73033c4985b601f96e9650d58fe6e83L128-R177) [[7]](diffhunk://#diff-b522fb3b70dd0c53a2c7c56b3ea8218fe73033c4985b601f96e9650d58fe6e83L172-R216) [[8]](diffhunk://#diff-b522fb3b70dd0c53a2c7c56b3ea8218fe73033c4985b601f96e9650d58fe6e83L210-L239)

### Code Cleanup:
* Removed redundant `console.log` statements across `date-utils.js` and `event-manager.js` to improve code cleanliness and reduce unnecessary debugging output. [[1]](diffhunk://#diff-5addde9c7b2e787e869fc169bd2275845bb76b6d71777b63356d6573065f0269L207-L209) [[2]](diffhunk://#diff-b522fb3b70dd0c53a2c7c56b3ea8218fe73033c4985b601f96e9650d58fe6e83L46-R76) [[3]](diffhunk://#diff-b522fb3b70dd0c53a2c7c56b3ea8218fe73033c4985b601f96e9650d58fe6e83L73-R102) [[4]](diffhunk://#diff-b522fb3b70dd0c53a2c7c56b3ea8218fe73033c4985b601f96e9650d58fe6e83L210-L239)

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

Mentions #
