### PR TITLE
Feature/add per page to event query loop

### DIFF
--- a/src/classes/class-se-block-variations.php
+++ b/src/classes/class-se-block-variations.php
@@ -101,9 +101,6 @@ class SE_Block_Variations {
 		// Change the post type.
 		$query['post_type'] = SE_Event_Post_Type::$event_date_post_type;
 
-		// Add filter to modify posts results
-		add_filter( 'the_posts', array( $this, 'modify_event_posts' ), 10, 2 );
-
 		return $this->set_event_query_args( $query, $feed_type, $feed_order );
 	}
 
@@ -162,7 +159,7 @@ class SE_Block_Variations {
 	public function set_admin_query( $args, $request ) {
 
 		$feed_type  = $request->get_param( 'feedType' );
-		$feed_order = $request->get_param( 'order' );
+		$feed_order = $request->get_param( 'order' );#
 
 		return $this->set_event_query_args( $args, $feed_type, $feed_order );
 	}
@@ -223,6 +220,9 @@ class SE_Block_Variations {
 		// Add a filter to modify the posts results.
 		add_filter( 'the_posts', array( $this, 'modify_event_posts' ), 10, 2 );
 
+		// Add a custom order by.
+		add_filter( 'posts_orderby', array( $this, 'fix_editor_sort_order' ), 10, 2 );
+
 		/**
 		 * A filter to customize the args of the event query loop.
 		 *
@@ -232,6 +232,29 @@ class SE_Block_Variations {
 		 */
 		return apply_filters( 'se_pre_set_event_query_loop_args', $args, $feed_type, $feed_order );
 	}
+
+	/**
+	 * Ensure the sort order is correctly set for the unique parents query.
+	 *
+	 * This fixes a weird bug where the admin/editor order is always ASC.
+	 *
+	 * @param string   $orderby The current orderby clause.
+	 * @param WP_Query $query   The WP_Query instance.
+	 *
+	 * @return string
+	 */
+	public function fix_editor_sort_order( $orderby, $query ) {
+		if ( isset( $query->query_vars['unique_parents'] ) && $query->query_vars['unique_parents'] ) {
+			if ( str_ends_with( $orderby, '+0 ASC' ) ) {
+				$feed_order = isset( $query->query_vars['feed_order'] ) ? $query->query_vars['feed_order'] : 'ASC';
+				$new_order  = sprintf( ' %s', strtoupper( $feed_order ) );
+				$orderby    = str_replace( '+0 ASC', $new_order, $orderby );
+			}
+		}
+
+		return $orderby;
+	}
+
 
 	/**
 	 * Filter posts to only include the correct event date for each parent.
@@ -247,6 +270,8 @@ class SE_Block_Variations {
 			return $where;
 		}
 
+		// adump( $query->query_vars['unique_parents'] );
+
 		// Skip if treating each date as own event
 		if ( se_event_treat_each_date_as_own_event() ) {
 			return $where;
@@ -256,7 +281,6 @@ class SE_Block_Variations {
 
 		$feed_order = $query->query_vars['feed_order'];
 		$meta_key   = 'desc' === $feed_order ? 'se_event_date_end' : 'se_event_date_start';
-
 		// Get the current time filtering from the main query's meta_query
 		$time_filter = '';
 		$meta_query  = $query->get( 'meta_query' );

--- a/src/classes/class-se-block-variations.php
+++ b/src/classes/class-se-block-variations.php
@@ -132,7 +132,7 @@ class SE_Block_Variations {
 				// Get the event timezone.
 				$timezone = get_post_meta( $parent->ID, 'se_event_timezone', true );
 				// use the timezone or default to the site timezone.
-				$timezone = $timezone ? $timezone : get_option( 'timezone_string' );
+				$timezone = $timezone ? $timezone : wp_timezone_string();
 
 				// Get the date im this format 2025-07-01 13:14:09
 				$start_date     = wp_date( 'Y-m-d H:i:s', $start_date_ts, new \DateTimeZone( $timezone ) );

--- a/src/variations/query-loop-events/block.js
+++ b/src/variations/query-loop-events/block.js
@@ -56,7 +56,7 @@ registerBlockVariation('core/query', {
 			perPage: 6,
 			pages: 0,
 			offset: 0,
-			postType: 'se-event-date',
+			postType: 'se-event',
 			order: 'asc',
 			orderBy: 'date',
 			author: '',
@@ -66,6 +66,7 @@ registerBlockVariation('core/query', {
 			inherit: false,
 			inheritTaxQuery: true,
 			feedType: 'default',
+			_cacheBuster: Date.now(),
 		},
 		eventsPerPage: 6,
 	},
@@ -83,6 +84,7 @@ registerBlockVariation('core/query', {
 	allowedControls: ['taxQuery', 'search', 'feedType'],
 });
 
+
 const FeedTypeControl = ({ attributes, setAttributes, clientId }) => {
 	const { query } = attributes;
 	const feedType = query.feedType || 'default';
@@ -99,6 +101,35 @@ const FeedTypeControl = ({ attributes, setAttributes, clientId }) => {
 		});
 	}, [feedType, feedOrder, clientId]);
 
+
+/**
+ * Gets options for feed order based on the type.
+ * @param {string} type The current feed type.
+ * @returns options for feed order based on the type.
+ */
+const getFeedOrderOptions = (type) => {
+	switch (type) {
+		case 'upcoming':
+			return [
+				{ label: 'Soonest First', value: 'asc' },
+				{ label: 'Furthest in Future First', value: 'desc' },
+			];
+		case 'past':
+			return [
+				{ label: 'Oldest First', value: 'asc' },
+				{ label: 'Most Recent First', value: 'desc' },
+			];
+		case 'default':
+		default:
+			return [
+				{ label: 'Oldest to Newest', value: 'asc' },
+				{ label: 'Newest to Oldest', value: 'desc' },
+			];
+	}
+};
+
+let feedOrderOptions = getFeedOrderOptions(feedType);
+
 	return (
 		<>
 			<SelectControl
@@ -114,6 +145,7 @@ const FeedTypeControl = ({ attributes, setAttributes, clientId }) => {
 						query: {
 							...query,
 							feedType: value,
+							_cacheBuster: Date.now()
 						},
 					});
 				}}
@@ -122,15 +154,13 @@ const FeedTypeControl = ({ attributes, setAttributes, clientId }) => {
 			<SelectControl
 				label="Feed Order"
 				value={feedOrder}
-				options={[
-					{ label: 'Oldest First', value: 'asc' },
-					{ label: 'Newest First', value: 'desc' },
-				]}
+				options={feedOrderOptions}
 				onChange={(value) => {
 					setAttributes({
 						query: {
 							...query,
 							order: value,
+							_cacheBuster: Date.now()
 						},
 					});
 				}}
@@ -145,6 +175,7 @@ const FeedTypeControl = ({ attributes, setAttributes, clientId }) => {
 						query: {
 							...query,
 							perPage: value,
+							_cacheBuster: Date.now()
 						},
 					});
 				}}

--- a/src/variations/query-loop-events/block.js
+++ b/src/variations/query-loop-events/block.js
@@ -7,9 +7,9 @@
 import { InspectorControls } from '@wordpress/block-editor';
 import { registerBlockType, registerBlockVariation } from '@wordpress/blocks';
 import { addFilter } from '@wordpress/hooks';
-import { PanelBody, SelectControl } from '@wordpress/components';
+import { PanelBody, SelectControl, RangeControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { useEffect } from '@wordpress/element';
+import { useEffect, useState } from '@wordpress/element';
 import { createReduxStore, register, dispatch, select } from '@wordpress/data';
 
 const EVENTS_VARIATION = 'se-events/query-loop-events';
@@ -56,7 +56,7 @@ registerBlockVariation('core/query', {
 			perPage: 6,
 			pages: 0,
 			offset: 0,
-			postType: 'se-event',
+			postType: 'se-event-date',
 			order: 'asc',
 			orderBy: 'date',
 			author: '',
@@ -67,10 +67,7 @@ registerBlockVariation('core/query', {
 			inheritTaxQuery: true,
 			feedType: 'default',
 		},
-	},
-	providesContext: {
-		'se-events/feedType': 'query.feedType',
-		'se-events/feedOrder': 'query.order',
+		eventsPerPage: 6,
 	},
 	innerBlocks: [
 		[
@@ -90,6 +87,9 @@ const FeedTypeControl = ({ attributes, setAttributes, clientId }) => {
 	const { query } = attributes;
 	const feedType = query.feedType || 'default';
 	const feedOrder = query.order || 'asc';
+	const [eventsPerPage, setEventsPerPage] = useState(
+		query.perPage || 6
+	);
 
 	// Store the query data so child blocks can access it
 	useEffect(() => {
@@ -136,6 +136,29 @@ const FeedTypeControl = ({ attributes, setAttributes, clientId }) => {
 				}}
 				__nextHasNoMarginBottom
 			/>
+			<RangeControl
+				label={__('Events per Page', 'simple-events')}
+				value={eventsPerPage}
+				onChange={(value) => {
+					setEventsPerPage(value);
+					setAttributes({
+						query: {
+							...query,
+							perPage: value,
+						},
+					});
+				}}
+				min={1}
+				max={100}
+				step={1}
+				__nextHasNoMarginBottom
+			/>
+			<p className="description">
+				{__(
+					'Select the type of events to display and their order.',
+					'simple-events'
+				)}
+			</p>
 		</>
 	);
 };


### PR DESCRIPTION
#### Changes proposed in this Pull Request

*
This pull request includes enhancements and fixes to the event query system and block editor functionality. Key changes focus on improving query customization, fixing sorting bugs, and adding new controls for the block editor. The changes are grouped into two main themes: backend query improvements and frontend block editor enhancements.

### Backend Query Improvements:
* Removed redundant `add_filter` call for modifying post results in `build_query` and moved it to `set_event_query_args` for better encapsulation. (`src/classes/class-se-block-variations.php`)
* Added a new filter `posts_orderby` to fix sorting issues in the editor, ensuring the correct order is applied based on the `feed_order` parameter. (`src/classes/class-se-block-variations.php`) [[1]](diffhunk://#diff-ad5ba332de2660ed7f161200695b0d68249aebc2f773959c433b664043d641d1R223-R225) [[2]](diffhunk://#diff-ad5ba332de2660ed7f161200695b0d68249aebc2f773959c433b664043d641d1R236-R258)
* Replaced the deprecated `get_option('timezone_string')` with `wp_timezone_string()` for better compatibility. (`src/classes/class-se-block-variations.php`)

### Frontend Block Editor Enhancements:
* Introduced a `RangeControl` to allow users to set the number of events displayed per page (`eventsPerPage`) in the block editor. (`src/variations/query-loop-events/block.js`) [[1]](diffhunk://#diff-5430c15b802833cc4cce57ef0c320ac6a414c13be2eef7623caf659c55a968a0L10-R12) [[2]](diffhunk://#diff-5430c15b802833cc4cce57ef0c320ac6a414c13be2eef7623caf659c55a968a0R87-R94) [[3]](diffhunk://#diff-5430c15b802833cc4cce57ef0c320ac6a414c13be2eef7623caf659c55a968a0L125-R192)
* Added dynamic feed order options based on the selected feed type (e.g., "upcoming" or "past") to improve user experience when configuring the block. (`src/variations/query-loop-events/block.js`)

These changes collectively enhance the flexibility and reliability of the event query system and improve the usability of the block editor for managing event-related content.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

Mentions #
